### PR TITLE
[fix] Align unsubsidized pricing display

### DIFF
--- a/src/app/api/pricing/route.ts
+++ b/src/app/api/pricing/route.ts
@@ -77,7 +77,7 @@ const ADDON_SERVICES = [
   {
     id: "breast-pump",
     name: "유축기 대여 서비스",
-    note: "정규 서비스 제공 시간 외 추가 시간",
+    note: "유축기 대여도 걱정없이 아가잼잼에서 해결",
     description: "",
     price: "5,000원",
     group: "care",

--- a/src/components/desktop/pages/pricing-client.tsx
+++ b/src/components/desktop/pages/pricing-client.tsx
@@ -95,7 +95,7 @@ const PLACEHOLDER_ADDONS: AddonData[] = [
     id: "ph-pump",
     name: "유축기 대여 서비스",
     description: "",
-    note: "정규 서비스 제공 시간 외 추가 시간",
+    note: "유축기 대여도 걱정없이 아가잼잼에서 해결",
     price: "---,---원",
     group: "care",
   },
@@ -122,6 +122,10 @@ const PLACEHOLDER_ADDONS: AddonData[] = [
     group: "schedule",
   },
 ];
+
+const UNSUBSIDIZED_HIDDEN_ADDON_IDS = new Set(["twins"]);
+const UNSUBSIDIZED_PLAN_ID_PREFIX = "unsub-";
+const CONSULTATION_REQUIRED_PRICE_LABEL = "상담 필요";
 
 interface DesktopPricingClientProps {
   "data-component"?: string;
@@ -163,27 +167,33 @@ export function DesktopPricingClient({
     [store.fetchPricing, store.selectedGradeName],
   );
 
-  const distinctCount = (store.selectedPlanId ? 1 : 0) + store.addonSelections.size;
-
   const displayPlans = store.pricesRevealed ? store.plans : PLACEHOLDER_PLANS;
-  const displayAddons = store.pricesRevealed ? store.addons : PLACEHOLDER_ADDONS;
+  const visibleAddons =
+    store.pricesRevealed && !isSubsidized
+      ? store.addons.filter((addon) => !UNSUBSIDIZED_HIDDEN_ADDON_IDS.has(addon.id))
+      : store.addons;
+  const displayAddons = store.pricesRevealed ? visibleAddons : PLACEHOLDER_ADDONS;
   const selectedPlan =
     store.plans.find((plan) => plan.id === store.selectedPlanId) ?? null;
+  const visibleSelectedPlan =
+    selectedPlan?.id.startsWith(UNSUBSIDIZED_PLAN_ID_PREFIX)
+      ? { ...selectedPlan, price: CONSULTATION_REQUIRED_PRICE_LABEL }
+      : selectedPlan;
   const selectedAddons = Array.from(store.addonSelections.entries())
     .map(([addonId, quantity]) => {
-      const addon = store.addons.find((item) => item.id === addonId);
+      const addon = visibleAddons.find((item) => item.id === addonId);
       return addon && quantity > 0 ? { addon, quantity } : null;
     })
     .filter(
       (item): item is { addon: AddonData; quantity: number } => item !== null,
     );
   const selectedServices: SelectedServicesPayload = {
-    plan: selectedPlan
+    plan: visibleSelectedPlan
       ? {
-          id: selectedPlan.id,
-          name: selectedPlan.name,
-          priceLabel: selectedPlan.price,
-          durationDays: selectedPlan.duration ?? null,
+          id: visibleSelectedPlan.id,
+          name: visibleSelectedPlan.name,
+          priceLabel: visibleSelectedPlan.price,
+          durationDays: visibleSelectedPlan.duration ?? null,
         }
       : null,
     addons: selectedAddons.map(({ addon, quantity }) => ({
@@ -194,6 +204,8 @@ export function DesktopPricingClient({
       group: addon.group ?? null,
     })),
   };
+  const distinctCount =
+    (store.selectedPlanId ? 1 : 0) + selectedAddons.length;
 
   return (
     <>
@@ -287,7 +299,7 @@ export function DesktopPricingClient({
         )}
       <DesktopFloatingBubble
         distinctCount={distinctCount}
-        selectedPlan={selectedPlan}
+        selectedPlan={visibleSelectedPlan}
         selectedAddons={selectedAddons}
         selectedServices={selectedServices}
         onRemovePlan={store.clearSelectedPlan}

--- a/src/components/desktop/sections/addon-services-section.tsx
+++ b/src/components/desktop/sections/addon-services-section.tsx
@@ -6,6 +6,9 @@ import {
   type AddonData,
 } from "@/components/molecules/addon-service-card";
 
+const BREAST_PUMP_ADDON_IDS = new Set(["breast-pump", "ph-pump"]);
+const BREAST_PUMP_NOTE = "유축기 대여도 걱정없이 아가잼잼에서 해결";
+
 interface DesktopAddonServicesSectionProps {
   addons: AddonData[];
   selections: Map<string, number>;
@@ -106,11 +109,17 @@ export function DesktopAddonServicesSection({
               {group.map((addon, addonIndex) => {
                 const quantity = selections.get(addon.id);
                 const added = quantity !== undefined && quantity > 0;
+                const displayedAddon = {
+                  ...addon,
+                  note: BREAST_PUMP_ADDON_IDS.has(addon.id)
+                    ? BREAST_PUMP_NOTE
+                    : addon.note,
+                };
 
                 return (
                   <AddonServiceCard
                     key={addon.id}
-                    addon={addon}
+                    addon={displayedAddon}
                     quantity={
                       added
                         ? quantity

--- a/src/components/desktop/sections/pricing-form-modal.tsx
+++ b/src/components/desktop/sections/pricing-form-modal.tsx
@@ -10,6 +10,12 @@ import {
 } from "@/lib/pricing/wizard";
 import { cn } from "@/lib/utils";
 
+function buildDesktopSteps(answers: PricingFormAnswers) {
+  return buildAllSteps(answers).filter(
+    (question) => !(answers.subsidy === "no" && question.id === "servicePeriod")
+  );
+}
+
 interface DesktopPricingFormModalProps {
   answers: PricingFormAnswers;
   onAnswer: (questionId: string, value: string) => void;
@@ -28,7 +34,7 @@ export function DesktopPricingFormModal({
   const getComponent = (suffix: string) =>
     dataComponent ? `${dataComponent}_${suffix}` : undefined;
 
-  const allSteps = buildAllSteps(answers);
+  const allSteps = buildDesktopSteps(answers);
   const currentQuestion = allSteps[step];
   const currentHelper =
     currentQuestion?.helperKey === SUBSIDY_ELIGIBILITY_HELPER_KEY ? (
@@ -48,15 +54,14 @@ export function DesktopPricingFormModal({
     ) : (
       currentQuestion?.helperKey ?? null
     );
-  const isMultiple = answers.childType && answers.childType !== "단태아";
-  const displayStepCount = answers.subsidy === "yes" ? (isMultiple ? 5 : 4) : 4;
+  const displayStepCount = answers.subsidy ? allSteps.length : 4;
 
   const handleSelect = useCallback(
     (questionId: string, value: string) => {
       onAnswer(questionId, value);
 
       const nextAnswers = { ...answers, [questionId]: value };
-      const nextSteps = buildAllSteps(nextAnswers);
+      const nextSteps = buildDesktopSteps(nextAnswers);
       const shouldSubmit = step >= nextSteps.length - 1;
 
       setTimeout(() => {

--- a/src/components/desktop/sections/pricing-plans-section.tsx
+++ b/src/components/desktop/sections/pricing-plans-section.tsx
@@ -8,6 +8,8 @@ import {
 import type { GradeName } from "@/lib/voucher-type";
 
 const GRADE_NAMES: GradeName[] = ["가", "통합", "라"];
+const UNSUBSIDIZED_PLAN_ID_PREFIX = "unsub-";
+const CONSULTATION_REQUIRED_PRICE_LABEL = "상담 필요";
 
 interface DesktopPricingPlansSectionProps {
   plans: PlanData[];
@@ -130,7 +132,11 @@ export function DesktopPricingPlansSection({
           {plans.map((plan, index) => (
             <PricingPlanCard
               key={plan.id}
-              plan={plan}
+              plan={
+                plan.id.startsWith(UNSUBSIDIZED_PLAN_ID_PREFIX)
+                  ? { ...plan, price: CONSULTATION_REQUIRED_PRICE_LABEL }
+                  : plan
+              }
               selected={plan.id === selectedPlanId}
               onSelect={() => onSelectPlan(plan.id)}
               isLoading={isLoading}

--- a/src/components/mobile/pages/pricing-client.tsx
+++ b/src/components/mobile/pages/pricing-client.tsx
@@ -95,7 +95,7 @@ const PLACEHOLDER_ADDONS: AddonData[] = [
     id: "ph-pump",
     name: "유축기 대여 서비스",
     description: "",
-    note: "정규 서비스 제공 시간 외 추가 시간",
+    note: "유축기 대여도 걱정없이 아가잼잼에서 해결",
     price: "---,---원",
     group: "care",
   },
@@ -122,6 +122,10 @@ const PLACEHOLDER_ADDONS: AddonData[] = [
     group: "schedule",
   },
 ];
+
+const UNSUBSIDIZED_HIDDEN_ADDON_IDS = new Set(["twins"]);
+const UNSUBSIDIZED_PLAN_ID_PREFIX = "unsub-";
+const CONSULTATION_REQUIRED_PRICE_LABEL = "상담 필요";
 
 interface MobilePricingClientProps {
   "data-component"?: string;
@@ -163,27 +167,33 @@ export function MobilePricingClient({
     [store.fetchPricing, store.selectedGradeName],
   );
 
-  const distinctCount = (store.selectedPlanId ? 1 : 0) + store.addonSelections.size;
-
   const displayPlans = store.pricesRevealed ? store.plans : PLACEHOLDER_PLANS;
-  const displayAddons = store.pricesRevealed ? store.addons : PLACEHOLDER_ADDONS;
+  const visibleAddons =
+    store.pricesRevealed && !isSubsidized
+      ? store.addons.filter((addon) => !UNSUBSIDIZED_HIDDEN_ADDON_IDS.has(addon.id))
+      : store.addons;
+  const displayAddons = store.pricesRevealed ? visibleAddons : PLACEHOLDER_ADDONS;
   const selectedPlan =
     store.plans.find((plan) => plan.id === store.selectedPlanId) ?? null;
+  const visibleSelectedPlan =
+    selectedPlan?.id.startsWith(UNSUBSIDIZED_PLAN_ID_PREFIX)
+      ? { ...selectedPlan, price: CONSULTATION_REQUIRED_PRICE_LABEL }
+      : selectedPlan;
   const selectedAddons = Array.from(store.addonSelections.entries())
     .map(([addonId, quantity]) => {
-      const addon = store.addons.find((item) => item.id === addonId);
+      const addon = visibleAddons.find((item) => item.id === addonId);
       return addon && quantity > 0 ? { addon, quantity } : null;
     })
     .filter(
       (item): item is { addon: AddonData; quantity: number } => item !== null,
     );
   const selectedServices: SelectedServicesPayload = {
-    plan: selectedPlan
+    plan: visibleSelectedPlan
       ? {
-          id: selectedPlan.id,
-          name: selectedPlan.name,
-          priceLabel: selectedPlan.price,
-          durationDays: selectedPlan.duration ?? null,
+          id: visibleSelectedPlan.id,
+          name: visibleSelectedPlan.name,
+          priceLabel: visibleSelectedPlan.price,
+          durationDays: visibleSelectedPlan.duration ?? null,
         }
       : null,
     addons: selectedAddons.map(({ addon, quantity }) => ({
@@ -194,6 +204,8 @@ export function MobilePricingClient({
       group: addon.group ?? null,
     })),
   };
+  const distinctCount =
+    (store.selectedPlanId ? 1 : 0) + selectedAddons.length;
 
   return (
     <>
@@ -291,7 +303,7 @@ export function MobilePricingClient({
         )}
       <MobileFloatingBubble
         distinctCount={distinctCount}
-        selectedPlan={selectedPlan}
+        selectedPlan={visibleSelectedPlan}
         selectedAddons={selectedAddons}
         selectedServices={selectedServices}
         onRemovePlan={store.clearSelectedPlan}

--- a/src/components/mobile/sections/addon-services-section.tsx
+++ b/src/components/mobile/sections/addon-services-section.tsx
@@ -9,6 +9,10 @@ import {
 } from "@/components/molecules/addon-service-card";
 import { GalleryPaddlenav } from "@/components/ui/gallery-paddlenav";
 
+const DAILY_PRICE_PREFIX = "일";
+const BREAST_PUMP_ADDON_IDS = new Set(["breast-pump", "ph-pump"]);
+const BREAST_PUMP_NOTE = "유축기 대여도 걱정없이 아가잼잼에서 해결";
+
 interface MobileAddonServicesSectionProps {
   addons: AddonData[];
   selections: Map<string, number>;
@@ -227,11 +231,21 @@ export function MobileAddonServicesSection({
               {group.map((addon, addonIndex) => {
                 const quantity = selections.get(addon.id);
                 const added = quantity !== undefined && quantity > 0;
+                const displayedAddon = {
+                  ...addon,
+                  note: BREAST_PUMP_ADDON_IDS.has(addon.id)
+                    ? BREAST_PUMP_NOTE
+                    : addon.note,
+                  price:
+                    groupIndex === 0
+                      ? `${DAILY_PRICE_PREFIX} ${addon.price}`
+                      : addon.price,
+                };
 
                 return (
                   <AddonServiceCard
                     key={addon.id}
-                    addon={addon}
+                    addon={displayedAddon}
                     quantity={
                       added
                         ? quantity

--- a/src/components/mobile/sections/pricing-plans-section.tsx
+++ b/src/components/mobile/sections/pricing-plans-section.tsx
@@ -11,6 +11,8 @@ import { GalleryPaddlenav } from "@/components/ui/gallery-paddlenav";
 import type { GradeName } from "@/lib/voucher-type";
 
 const GRADE_NAMES: GradeName[] = ["가", "통합", "라"];
+const UNSUBSIDIZED_PLAN_ID_PREFIX = "unsub-";
+const CONSULTATION_REQUIRED_PRICE_LABEL = "상담 필요";
 
 interface MobilePricingPlansSectionProps {
   plans: PlanData[];
@@ -220,7 +222,11 @@ export function MobilePricingPlansSection({
           {plans.map((plan, index) => (
             <PricingPlanCard
               key={plan.id}
-              plan={plan}
+              plan={
+                plan.id.startsWith(UNSUBSIDIZED_PLAN_ID_PREFIX)
+                  ? { ...plan, price: CONSULTATION_REQUIRED_PRICE_LABEL }
+                  : plan
+              }
               selected={plan.id === selectedPlanId}
               onSelect={() => onSelectPlan(plan.id)}
               isLoading={isLoading}


### PR DESCRIPTION
## Summary

- Show unsubsidized plan prices as `상담 필요` across mobile and desktop plan cards.
- Keep floating cart and booking selected-services payload aligned with the same consultation-required label.
- Hide twin-care add-on for unsubsidized pricing and update breast-pump add-on copy, including persisted add-on render normalization.
- Match desktop pricing form modal step flow to mobile by skipping service-period for unsubsidized users.

## Test Plan

- `npm run type-check`
- `npm run build`

## Related

- Closes #25
