### PR TITLE
fix: declare Pretendard variable font weight range

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ const pretendard = localFont({
   src: "./fonts/Pretendard.woff2",
   variable: "--font-pretendard",
   display: "swap",
+  weight: "100 900",
 });
 
 const paperlogy = localFont({


### PR DESCRIPTION
## Summary
- Pretendard.woff2 is the variable font (100–900) but `localFont` defaulted to `weight: normal`, so requests for `font-weight: 600/800` either synthesized bold or fell back to system fonts.
- Result: headings rendered as `-apple-system` (SF Pro / Apple SD Gothic Neo) on iOS Chrome and `sans-serif` (Roboto / Noto Sans CJK) on Android Chrome — visibly different weights and shapes per platform.
- Adding `weight: "100 900"` lets the single variable file serve every CSS weight from one `@font-face`.

## Test plan
- [x] `npm run build` succeeds
- [ ] Verify headings render with consistent Pretendard weight on iOS Chrome and Android Chrome

https://claude.ai/code/session_01DnPMMvSbAa4SmFap1gLrAx

---
_Generated by [Claude Code](https://claude.ai/code/session_01DnPMMvSbAa4SmFap1gLrAx)_