### PR TITLE
[codex] Improve PostHog and Sentry observability

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,36 +1,29 @@
 import * as Sentry from "@sentry/nextjs";
-import posthog from "posthog-js";
+
+import { initPostHog } from "@/lib/posthog-client";
 
 const appEnv = process.env.NEXT_PUBLIC_APP_ENV ?? "local";
+const sentryDsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
 const tracesSampleRate = appEnv === "production" ? 0.1 : appEnv === "preview" ? 0.3 : 1.0;
 const replaysOnErrorSampleRate = appEnv === "local" ? 0 : 1.0;
 
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  environment: appEnv,
-  tracesSampleRate,
-  replaysOnErrorSampleRate,
-  replaysSessionSampleRate: 0,
-  integrations: [
-    Sentry.replayIntegration({
-      maskAllText: true,
-      maskAllInputs: true,
-      blockAllMedia: true,
-    }),
-  ],
-});
+if (sentryDsn) {
+  Sentry.init({
+    dsn: sentryDsn,
+    environment: appEnv,
+    tracesSampleRate,
+    replaysOnErrorSampleRate,
+    replaysSessionSampleRate: 0,
+    integrations: [
+      Sentry.replayIntegration({
+        maskAllText: true,
+        maskAllInputs: true,
+        blockAllMedia: true,
+      }),
+    ],
+  });
+}
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;
 
-posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN!, {
-  api_host: "/ingest",
-  ui_host: "https://us.posthog.com",
-  defaults: "2026-01-30",
-  capture_exceptions: true,
-  debug: process.env.NODE_ENV === "development",
-  session_recording: {
-    maskAllInputs: true,
-    maskTextSelector: "*",
-    blockSelector: "[data-ph-block]",
-  },
-});
+initPostHog();

--- a/next.config.ts
+++ b/next.config.ts
@@ -22,7 +22,13 @@ const nextConfig: NextConfig = {
   skipTrailingSlashRedirect: true,
 };
 
-export default withSentryConfig(nextConfig, {
+const hasSentryUploadConfig = Boolean(
+  process.env.SENTRY_ORG &&
+    process.env.SENTRY_PROJECT &&
+    process.env.SENTRY_AUTH_TOKEN
+);
+
+const sentryConfig = {
   org: process.env.SENTRY_ORG,
   project: process.env.SENTRY_PROJECT,
   authToken: process.env.SENTRY_AUTH_TOKEN,
@@ -33,7 +39,11 @@ export default withSentryConfig(nextConfig, {
       removeDebugLogging: true,
     },
   },
-  errorHandler: (error) => {
+  errorHandler: (error: unknown) => {
     console.warn("[sentry] build wrapper error:", error);
   },
-});
+};
+
+export default hasSentryUploadConfig
+  ? withSentryConfig(nextConfig, sentryConfig)
+  : nextConfig;

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -1,10 +1,13 @@
 import * as Sentry from "@sentry/nextjs";
 
 const appEnv = process.env.NEXT_PUBLIC_APP_ENV ?? "local";
+const sentryDsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
 const tracesSampleRate = appEnv === "production" ? 0.1 : 0.5;
 
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  environment: appEnv,
-  tracesSampleRate,
-});
+if (sentryDsn) {
+  Sentry.init({
+    dsn: sentryDsn,
+    environment: appEnv,
+    tracesSampleRate,
+  });
+}

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,21 +1,24 @@
 import * as Sentry from "@sentry/nextjs";
 
 const appEnv = process.env.NEXT_PUBLIC_APP_ENV ?? "local";
+const sentryDsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
 const tracesSampleRate = appEnv === "production" ? 0.1 : appEnv === "preview" ? 0.3 : 1.0;
 
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  environment: appEnv,
-  tracesSampleRate,
-  beforeSend(event) {
-    if (event.request) {
-      delete event.request.data;
-      delete event.request.cookies;
-      if (event.request.headers) {
-        delete event.request.headers["cookie"];
-        delete event.request.headers["authorization"];
+if (sentryDsn) {
+  Sentry.init({
+    dsn: sentryDsn,
+    environment: appEnv,
+    tracesSampleRate,
+    beforeSend(event) {
+      if (event.request) {
+        delete event.request.data;
+        delete event.request.cookies;
+        if (event.request.headers) {
+          delete event.request.headers["cookie"];
+          delete event.request.headers["authorization"];
+        }
       }
-    }
-    return event;
-  },
-});
+      return event;
+    },
+  });
+}

--- a/src/app/api/consultation-inquiries/route.ts
+++ b/src/app/api/consultation-inquiries/route.ts
@@ -1,6 +1,10 @@
 import * as Sentry from "@sentry/nextjs";
 import { NextResponse } from "next/server";
-import { getPostHogClient } from "@/lib/posthog-server";
+
+import {
+  capturePostHogServerEvent,
+  capturePostHogServerException,
+} from "@/lib/posthog-server";
 
 const BACKEND_URL =
   process.env.BJJ_API_URL ?? "https://api.babyjamjam.com";
@@ -19,7 +23,6 @@ interface ConsultationInquiryBody {
 }
 
 export async function POST(request: Request) {
-  const posthog = getPostHogClient();
   let body: ConsultationInquiryBody | null = null;
 
   try {
@@ -33,7 +36,7 @@ export async function POST(request: Request) {
     const payload = await res.json().catch(() => null);
 
     if (!res.ok) {
-      posthog.capture({
+      await capturePostHogServerEvent({
         distinctId: body?.branchSlug ?? "anonymous",
         event: "consultation_inquiry_failed",
         properties: {
@@ -49,7 +52,7 @@ export async function POST(request: Request) {
       );
     }
 
-    posthog.capture({
+    await capturePostHogServerEvent({
       distinctId: body?.branchSlug ?? "anonymous",
       event: "consultation_inquiry_submitted",
       properties: {
@@ -76,11 +79,11 @@ export async function POST(request: Request) {
               preferredCaregiverName: !!body.preferredCaregiverName,
               referralSource: !!body.referralSource,
               additionalNotes: !!body.additionalNotes,
-            }
+        }
           : null,
       },
     });
-    posthog.captureException(error, "anonymous");
+    await capturePostHogServerException(error, "anonymous");
     return NextResponse.json(
       { error: "상담 신청에 실패했습니다." },
       { status: 500 }

--- a/src/components/desktop/chrome/booking-button.tsx
+++ b/src/components/desktop/chrome/booking-button.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import posthog from "posthog-js";
 
 import { PillCta } from "@/components/ui/circle-cta";
+import { capturePostHogEvent } from "@/lib/posthog-client";
 
 import { DesktopBookingModal } from "./booking-modal";
 
@@ -25,7 +25,7 @@ export function DesktopBookingButton({
       <PillCta
         data-component="desktop_chrome_booking-button_trigger"
         onClick={() => {
-          posthog.capture("consultation_modal_opened", { source: "desktop" });
+          capturePostHogEvent("consultation_modal_opened", { source: "desktop" });
           setOpen(true);
         }}
       >

--- a/src/components/desktop/chrome/booking-modal.tsx
+++ b/src/components/desktop/chrome/booking-modal.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useCallback, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
-import posthog from "posthog-js";
 
 import {
   findBranchByRegionDistrict,
@@ -26,6 +25,10 @@ import type {
   ConsultationSelectedServices as SelectedServicesPayload,
   ConsultationTouchedState,
 } from "@/lib/consultation/contracts";
+import {
+  capturePostHogEvent,
+  capturePostHogException,
+} from "@/lib/posthog-client";
 import { VOUCHER_TYPE_OPTIONS } from "@/lib/voucher-type";
 
 import {
@@ -220,7 +223,7 @@ export function DesktopBookingModal({
 
   const handleMunicipalitySelect = useCallback(
     (province: string, municipality: string) => {
-      posthog.capture("consultation_region_selected", {
+      capturePostHogEvent("consultation_region_selected", {
         province,
         municipality,
         source: "desktop",
@@ -308,11 +311,22 @@ export function DesktopBookingModal({
     setSubmitAttempted(true);
 
     if (Object.values(nextErrors).some(Boolean)) {
+      capturePostHogEvent("consultation_validation_failed", {
+        field_errors: Object.keys(nextErrors).filter((key) =>
+          Boolean(nextErrors[key as keyof typeof nextErrors])
+        ),
+        source: "desktop",
+      });
       setSubmitError(null);
       return;
     }
 
     if (!branchSlug) {
+      capturePostHogEvent("consultation_branch_missing", {
+        province: selectedProvince,
+        municipality: selectedMuni,
+        source: "desktop",
+      });
       setSubmitError(
         "상담 가능한 지점을 찾을 수 없습니다. 지역을 다시 선택해 주세요."
       );
@@ -347,7 +361,7 @@ export function DesktopBookingModal({
         throw new Error(message);
       }
 
-      posthog.capture("consultation_form_submitted", {
+      capturePostHogEvent("consultation_form_submitted", {
         branch_slug: branchSlug,
         referral_source: form.referralSource,
         birth_experience: form.birthExperience,
@@ -362,17 +376,24 @@ export function DesktopBookingModal({
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : "상담 신청에 실패했습니다.";
-      posthog.capture("consultation_submission_failed", {
+      capturePostHogEvent("consultation_submission_failed", {
         error_message: errorMessage,
         branch_slug: branchSlug,
         source: "desktop",
       });
-      posthog.captureException(error);
+      capturePostHogException(error);
       setSubmitError(errorMessage);
     } finally {
       setIsSubmitting(false);
     }
-  }, [form, selectedBranch?.id, selectedBranchSlug, selectedServices]);
+  }, [
+    form,
+    selectedBranch?.id,
+    selectedBranchSlug,
+    selectedMuni,
+    selectedProvince,
+    selectedServices,
+  ]);
 
   const handleSuccessBack = useCallback(() => {
     setSubmitted(false);

--- a/src/components/desktop/chrome/floating-bubble.tsx
+++ b/src/components/desktop/chrome/floating-bubble.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { X } from "lucide-react";
-import posthog from "posthog-js";
 import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
@@ -10,6 +9,7 @@ import type { PlanData } from "@/components/molecules/pricing-plan-card";
 import { PillCta } from "@/components/ui/circle-cta";
 import { QuantityStepper } from "@/components/ui/quantity-stepper";
 import type { ConsultationSelectedServices as SelectedServicesPayload } from "@/lib/consultation/contracts";
+import { capturePostHogEvent } from "@/lib/posthog-client";
 
 import { DesktopBookingModal } from "./booking-modal";
 
@@ -145,7 +145,7 @@ export function DesktopFloatingBubble({
             <PillCta
               className="floating-cart-panel__cta"
               onClick={() => {
-                posthog.capture("consultation_modal_opened", {
+                capturePostHogEvent("consultation_modal_opened", {
                   source: "desktop_floating_bubble",
                 });
                 setIsBookingOpen(true);

--- a/src/components/desktop/pages/locations.tsx
+++ b/src/components/desktop/pages/locations.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import posthog from "posthog-js";
 import { useMemo, useState, useCallback } from "react";
 
 import { DesktopBookingModal as BookingModal } from "@/components/desktop/chrome/booking-modal";
@@ -9,6 +8,7 @@ import { KoreaRegionMap } from "@/components/korea-region-map";
 import { Badge } from "@/components/ui/badge";
 import { PillCta } from "@/components/ui/circle-cta";
 import { BRANCHES } from "@/data/branches";
+import { capturePostHogEvent } from "@/lib/posthog-client";
 
 export default function DesktopLocationsPage() {
   const [selectedRegion, setSelectedRegion] = useState<string | null>(null);
@@ -29,6 +29,10 @@ export default function DesktopLocationsPage() {
     : BRANCHES;
 
   const handleRegionSelect = useCallback((region: string | null) => {
+    capturePostHogEvent("locations_region_selected", {
+      region,
+      source: "desktop_locations_map",
+    });
     setSelectedRegion(region);
   }, []);
 
@@ -158,7 +162,7 @@ export default function DesktopLocationsPage() {
                     data-component="desktop_locations_page_booking_cta"
                     onClick={(event) => {
                       event.stopPropagation();
-                      posthog.capture("consultation_modal_opened", {
+                      capturePostHogEvent("consultation_modal_opened", {
                         source: "desktop_locations_inline",
                         branch_id: branch.id,
                       });

--- a/src/components/desktop/pages/pricing-client.tsx
+++ b/src/components/desktop/pages/pricing-client.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import posthog from "posthog-js";
 
 import { DesktopFloatingBubble } from "@/components/desktop/chrome/floating-bubble";
 import { DesktopAddonServicesSection } from "@/components/desktop/sections/addon-services-section";
@@ -13,6 +12,7 @@ import type { PlanData } from "@/components/molecules/pricing-plan-card";
 import type { ConsultationSelectedServices as SelectedServicesPayload } from "@/lib/consultation/contracts";
 import type { FormAnswers as PricingFormAnswers } from "@/lib/pricing/contracts";
 import { usePricingStore } from "@/lib/pricing-store";
+import { capturePostHogEvent } from "@/lib/posthog-client";
 import { resolveVoucherTypeFromPricingAnswers } from "@/lib/voucher-type";
 
 const PLACEHOLDER_PLANS: PlanData[] = [
@@ -260,7 +260,7 @@ export function DesktopPricingClient({
                 type="button"
                 className="pricing-cta-card__btn"
                 onClick={() => {
-                  posthog.capture("pricing_wizard_started", { source: "desktop" });
+                  capturePostHogEvent("pricing_wizard_started", { source: "desktop" });
                   setShowFormModal(true);
                 }}
                 data-component={getComponent("cta-button")}

--- a/src/components/desktop/sections/pricing-form-modal.tsx
+++ b/src/components/desktop/sections/pricing-form-modal.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useCallback, useState } from "react";
-import posthog from "posthog-js";
 
 import { SelectDropdown } from "@/components/ui/select-dropdown";
+import { capturePostHogEvent } from "@/lib/posthog-client";
 import type { FormAnswers as PricingFormAnswers } from "@/lib/pricing/contracts";
 import {
   buildAllSteps,
@@ -65,7 +65,7 @@ export function DesktopPricingFormModal({
       const nextSteps = buildDesktopSteps(nextAnswers);
       const shouldSubmit = step >= nextSteps.length - 1;
 
-      posthog.capture("pricing_wizard_answer_selected", {
+      capturePostHogEvent("pricing_wizard_answer_selected", {
         question_id: questionId,
         value,
         step: step + 1,

--- a/src/components/desktop/sections/pricing-plans-section.tsx
+++ b/src/components/desktop/sections/pricing-plans-section.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import posthog from "posthog-js";
 import { cn } from "@/lib/utils";
 import {
   PricingPlanCard,
   type PlanData,
 } from "@/components/molecules/pricing-plan-card";
+import { capturePostHogEvent } from "@/lib/posthog-client";
 import type { GradeName } from "@/lib/voucher-type";
 
 const GRADE_NAMES: GradeName[] = ["가", "통합", "라"];
@@ -140,7 +140,7 @@ export function DesktopPricingPlansSection({
               }
               selected={plan.id === selectedPlanId}
               onSelect={() => {
-                posthog.capture("pricing_plan_selected", {
+                capturePostHogEvent("pricing_plan_selected", {
                   plan_id: plan.id,
                   plan_name: plan.name,
                   source: "desktop",

--- a/src/components/mobile/chrome/booking-button.tsx
+++ b/src/components/mobile/chrome/booking-button.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import posthog from "posthog-js";
 
 import { PillCta } from "@/components/ui/circle-cta";
+import { capturePostHogEvent } from "@/lib/posthog-client";
 
 import { MobileBookingModal } from "./booking-modal";
 
@@ -25,7 +25,7 @@ export function MobileBookingButton({
       <PillCta
         data-component="mobile_chrome_booking-button_trigger"
         onClick={() => {
-          posthog.capture("consultation_modal_opened", { source: "mobile" });
+          capturePostHogEvent("consultation_modal_opened", { source: "mobile" });
           setOpen(true);
         }}
       >

--- a/src/components/mobile/chrome/booking-modal.tsx
+++ b/src/components/mobile/chrome/booking-modal.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useCallback, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
-import posthog from "posthog-js";
 
 import {
   findBranchByRegionDistrict,
@@ -26,6 +25,10 @@ import type {
   ConsultationSelectedServices as SelectedServicesPayload,
   ConsultationTouchedState,
 } from "@/lib/consultation/contracts";
+import {
+  capturePostHogEvent,
+  capturePostHogException,
+} from "@/lib/posthog-client";
 import { VOUCHER_TYPE_OPTIONS } from "@/lib/voucher-type";
 
 import {
@@ -220,7 +223,7 @@ export function MobileBookingModal({
 
   const handleMunicipalitySelect = useCallback(
     (province: string, municipality: string) => {
-      posthog.capture("consultation_region_selected", {
+      capturePostHogEvent("consultation_region_selected", {
         province,
         municipality,
         source: "mobile",
@@ -308,11 +311,22 @@ export function MobileBookingModal({
     setSubmitAttempted(true);
 
     if (Object.values(nextErrors).some(Boolean)) {
+      capturePostHogEvent("consultation_validation_failed", {
+        field_errors: Object.keys(nextErrors).filter((key) =>
+          Boolean(nextErrors[key as keyof typeof nextErrors])
+        ),
+        source: "mobile",
+      });
       setSubmitError(null);
       return;
     }
 
     if (!branchSlug) {
+      capturePostHogEvent("consultation_branch_missing", {
+        province: selectedProvince,
+        municipality: selectedMuni,
+        source: "mobile",
+      });
       setSubmitError(
         "상담 가능한 지점을 찾을 수 없습니다. 지역을 다시 선택해 주세요."
       );
@@ -347,7 +361,7 @@ export function MobileBookingModal({
         throw new Error(message);
       }
 
-      posthog.capture("consultation_form_submitted", {
+      capturePostHogEvent("consultation_form_submitted", {
         branch_slug: branchSlug,
         referral_source: form.referralSource,
         birth_experience: form.birthExperience,
@@ -362,17 +376,24 @@ export function MobileBookingModal({
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : "상담 신청에 실패했습니다.";
-      posthog.capture("consultation_submission_failed", {
+      capturePostHogEvent("consultation_submission_failed", {
         error_message: errorMessage,
         branch_slug: branchSlug,
         source: "mobile",
       });
-      posthog.captureException(error);
+      capturePostHogException(error);
       setSubmitError(errorMessage);
     } finally {
       setIsSubmitting(false);
     }
-  }, [form, selectedBranch?.id, selectedBranchSlug, selectedServices]);
+  }, [
+    form,
+    selectedBranch?.id,
+    selectedBranchSlug,
+    selectedMuni,
+    selectedProvince,
+    selectedServices,
+  ]);
 
   const handleSuccessBack = useCallback(() => {
     setSubmitted(false);

--- a/src/components/mobile/chrome/floating-bubble.tsx
+++ b/src/components/mobile/chrome/floating-bubble.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { X } from "lucide-react";
-import posthog from "posthog-js";
 import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
@@ -10,6 +9,7 @@ import type { PlanData } from "@/components/molecules/pricing-plan-card";
 import { PillCta } from "@/components/ui/circle-cta";
 import { QuantityStepper } from "@/components/ui/quantity-stepper";
 import type { ConsultationSelectedServices as SelectedServicesPayload } from "@/lib/consultation/contracts";
+import { capturePostHogEvent } from "@/lib/posthog-client";
 
 import { MobileBookingModal } from "./booking-modal";
 
@@ -145,7 +145,7 @@ export function MobileFloatingBubble({
             <PillCta
               className="floating-cart-panel__cta"
               onClick={() => {
-                posthog.capture("consultation_modal_opened", {
+                capturePostHogEvent("consultation_modal_opened", {
                   source: "mobile_floating_bubble",
                 });
                 setIsBookingOpen(true);

--- a/src/components/mobile/pages/locations.tsx
+++ b/src/components/mobile/pages/locations.tsx
@@ -9,6 +9,7 @@ import { KoreaRegionMap } from "@/components/korea-region-map";
 import { Badge } from "@/components/ui/badge";
 import { PillCta } from "@/components/ui/circle-cta";
 import { BRANCHES } from "@/data/branches";
+import { capturePostHogEvent } from "@/lib/posthog-client";
 
 export default function MobileLocationsPage() {
   const [selectedRegion, setSelectedRegion] = useState<string | null>(null);
@@ -29,6 +30,10 @@ export default function MobileLocationsPage() {
     : BRANCHES;
 
   const handleRegionSelect = useCallback((region: string | null) => {
+    capturePostHogEvent("locations_region_selected", {
+      region,
+      source: "mobile_locations_map",
+    });
     setSelectedRegion(region);
   }, []);
 
@@ -162,6 +167,10 @@ export default function MobileLocationsPage() {
                     data-component="mobile_locations_page_booking_cta"
                     onClick={(event) => {
                       event.stopPropagation();
+                      capturePostHogEvent("consultation_modal_opened", {
+                        source: "mobile_locations_inline",
+                        branch_id: branch.id,
+                      });
                       setBookingRegion(branch.region);
                       setBookingDistrict(branch.district);
                       setBookingBranchSlug(branch.id);

--- a/src/components/mobile/pages/pricing-client.tsx
+++ b/src/components/mobile/pages/pricing-client.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import posthog from "posthog-js";
 
 import { MobileFloatingBubble } from "@/components/mobile/chrome/floating-bubble";
 import { MobileAddonServicesSection } from "@/components/mobile/sections/addon-services-section";
@@ -13,6 +12,7 @@ import type { PlanData } from "@/components/molecules/pricing-plan-card";
 import type { ConsultationSelectedServices as SelectedServicesPayload } from "@/lib/consultation/contracts";
 import type { FormAnswers as PricingFormAnswers } from "@/lib/pricing/contracts";
 import { usePricingStore } from "@/lib/pricing-store";
+import { capturePostHogEvent } from "@/lib/posthog-client";
 import { resolveVoucherTypeFromPricingAnswers } from "@/lib/voucher-type";
 
 const PLACEHOLDER_PLANS: PlanData[] = [
@@ -264,7 +264,7 @@ export function MobilePricingClient({
                 type="button"
                 className="pricing-cta-card__btn"
                 onClick={() => {
-                  posthog.capture("pricing_wizard_started", { source: "mobile" });
+                  capturePostHogEvent("pricing_wizard_started", { source: "mobile" });
                   setShowFormModal(true);
                 }}
                 data-component={getComponent("cta-button")}

--- a/src/components/mobile/sections/pricing-form-modal.tsx
+++ b/src/components/mobile/sections/pricing-form-modal.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useState } from "react";
 
 import { SelectDropdown } from "@/components/ui/select-dropdown";
+import { capturePostHogEvent } from "@/lib/posthog-client";
 import type { FormAnswers as PricingFormAnswers } from "@/lib/pricing/contracts";
 import {
   buildAllSteps,
@@ -64,6 +65,14 @@ export function MobilePricingFormModal({
       const nextAnswers = { ...answers, [questionId]: value };
       const nextSteps = buildMobileSteps(nextAnswers);
       const shouldSubmit = step >= nextSteps.length - 1;
+
+      capturePostHogEvent("pricing_wizard_answer_selected", {
+        question_id: questionId,
+        value,
+        step: step + 1,
+        is_final_step: shouldSubmit,
+        source: "mobile",
+      });
 
       setTimeout(() => {
         if (shouldSubmit) {

--- a/src/components/mobile/sections/pricing-plans-section.tsx
+++ b/src/components/mobile/sections/pricing-plans-section.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 
+import { capturePostHogEvent } from "@/lib/posthog-client";
 import { cn } from "@/lib/utils";
 import {
   PricingPlanCard,
@@ -228,7 +229,14 @@ export function MobilePricingPlansSection({
                   : plan
               }
               selected={plan.id === selectedPlanId}
-              onSelect={() => onSelectPlan(plan.id)}
+              onSelect={() => {
+                capturePostHogEvent("pricing_plan_selected", {
+                  plan_id: plan.id,
+                  plan_name: plan.name,
+                  source: "mobile",
+                });
+                onSelectPlan(plan.id);
+              }}
               isLoading={isLoading}
               data-component={getComponent(`card-${index + 1}`)}
             />

--- a/src/lib/posthog-client.ts
+++ b/src/lib/posthog-client.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import posthog from "posthog-js";
+
+type PostHogProperties = Record<string, unknown>;
+
+const posthogProjectToken = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+
+export function initPostHog(): void {
+  if (!posthogProjectToken || posthog.__loaded) return;
+
+  posthog.init(posthogProjectToken, {
+    api_host: "/ingest",
+    ui_host: "https://us.posthog.com",
+    defaults: "2026-01-30",
+    capture_exceptions: true,
+    debug: process.env.NODE_ENV === "development",
+    session_recording: {
+      maskAllInputs: true,
+      maskTextSelector: "*",
+      blockSelector: "[data-ph-block]",
+    },
+  });
+}
+
+export function capturePostHogEvent(
+  eventName: string,
+  properties?: PostHogProperties
+): void {
+  if (!posthogProjectToken) return;
+
+  initPostHog();
+  posthog.capture(eventName, properties, { send_instantly: true });
+}
+
+export function capturePostHogException(error: unknown): void {
+  if (!posthogProjectToken) return;
+
+  initPostHog();
+  posthog.captureException(error);
+}

--- a/src/lib/posthog-server.ts
+++ b/src/lib/posthog-server.ts
@@ -1,17 +1,44 @@
 import { PostHog } from "posthog-node";
+import type { EventMessage } from "posthog-node";
 
 let posthogClient: PostHog | null = null;
 
-export function getPostHogClient() {
+export function getPostHogClient(): PostHog | null {
+  const posthogProjectToken =
+    process.env.POSTHOG_PROJECT_TOKEN ??
+    process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+
+  if (!posthogProjectToken) return null;
+
   if (!posthogClient) {
     posthogClient = new PostHog(
-      process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN!,
+      posthogProjectToken,
       {
-        host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+        host: process.env.POSTHOG_HOST ?? process.env.NEXT_PUBLIC_POSTHOG_HOST,
         flushAt: 1,
         flushInterval: 0,
       }
     );
   }
   return posthogClient;
+}
+
+export async function capturePostHogServerEvent(
+  event: EventMessage
+): Promise<void> {
+  const posthog = getPostHogClient();
+  if (!posthog) return;
+
+  await posthog.captureImmediate(event).catch(() => undefined);
+}
+
+export async function capturePostHogServerException(
+  error: unknown,
+  distinctId: string
+): Promise<void> {
+  const posthog = getPostHogClient();
+  if (!posthog) return;
+
+  posthog.captureException(error, distinctId);
+  await posthog.flush().catch(() => undefined);
 }

--- a/src/lib/pricing-store.ts
+++ b/src/lib/pricing-store.ts
@@ -1,7 +1,10 @@
+import * as Sentry from "@sentry/nextjs";
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
+
 import type { PlanData } from "@/components/molecules/pricing-plan-card";
 import type { AddonData } from "@/components/molecules/addon-service-card";
+import { capturePostHogEvent } from "@/lib/posthog-client";
 import type { FormAnswers as PricingFormAnswers } from "@/lib/pricing/contracts";
 import type { GradeName } from "@/lib/voucher-type";
 import { resolveVoucherTypeFromPricingAnswers } from "@/lib/voucher-type";
@@ -135,7 +138,23 @@ export const usePricingStore = create<PricingState & PricingActions>()(
             selectedPlanId: null,
             addonSelections: new Map(),
           });
-        } catch {
+        } catch (error) {
+          const errorMessage =
+            error instanceof Error ? error.message : "가격 조회에 실패했습니다.";
+          capturePostHogEvent("pricing_fetch_failed", {
+            error_message: errorMessage,
+            subsidy: formAnswers.subsidy,
+            child_type: formAnswers.childType,
+            grade_name: gradeName,
+          });
+          Sentry.captureException(error, {
+            tags: { feature: "pricing" },
+            extra: {
+              subsidy: formAnswers.subsidy,
+              childType: formAnswers.childType,
+              gradeName,
+            },
+          });
           set({ isLoading: false });
         }
       },


### PR DESCRIPTION
## Summary

- Guard Sentry client/server/edge initialization behind DSN availability and strip sensitive server request data before sending events.
- Centralize browser PostHog setup behind a token-aware helper and route component capture calls through it.
- Add server PostHog helpers for consultation API success/failure capture.
- Fill missing PostHog events across pricing, locations, booking modal validation, and pricing fetch failures.

## Validation

- `pnpm run type-check` passed.
- `pnpm run build` passed.
- `git diff --check` passed.
- Production `next start` network verification confirmed decoded PostHog events for desktop/mobile pricing and locations, with no token warning and no console errors.
- `pnpm run lint` still fails before linting because this repo script calls `next lint`, which Next 16 interprets as `/Users/jaino/Development/babyjamjam/dev/lint`.